### PR TITLE
[#132] Fixed broken master/docs/ links

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ While every effort has been made to make sure Shadows performs across a variety 
 
 ## Contributing
 
-You can help make Shadows better. Please read [CONTRIBUTING.md](https://github.com/mivaecommerce/readytheme-shadows/blob/master/docs/CONTRIBUTING.md) to see how you can participate.
+You can help make Shadows better. Please read [CONTRIBUTING.md](https://github.com/mivaecommerce/readytheme-shadows/blob/master/CONTRIBUTING.md) to see how you can participate.
 
 ## Licensing
 

--- a/css-style-guide.md
+++ b/css-style-guide.md
@@ -23,7 +23,7 @@
 
 ### Template
 
-Before diving into the details of CSS coding style, you can find a conforming, `.css` template over at [https://git.io/vdoF3](https://github.com/mivaecommerce/readytheme-shadows/blob/master/docs/stylesheet-template.css).
+Before diving into the details of CSS coding style, you can find a conforming, `.css` template over at [https://git.io/vdoF3](https://github.com/mivaecommerce/readytheme-shadows/blob/master/stylesheet-template.css).
 
 [⬆ Back to contents](#contents)
 


### PR DESCRIPTION
Fixed links referencing master/docs/ by changing them to just master/